### PR TITLE
Use more specific CSS selectors

### DIFF
--- a/assets/css/sis-style.css
+++ b/assets/css/sis-style.css
@@ -14,7 +14,7 @@ input.h, input.w {
 	-webkit-border-radius: 3px;
 	border-radius: 3px;
 }
-tr {
+table.sis tr {
 	-webkit-transition: all .5s ease-in-out;
 	-moz-transition: all .5s ease-in-out;
 	-o-transition: all .5s ease-in-out;


### PR DESCRIPTION
The general `tr` CSS selector here was causing conflicts with other WordPress plugins that move table rows in the Admin screens. I'm not sure what the purpose of applying this animation is, but I propose that it should be a more specific CSS selector that only applies to SIS tables; `table.sis tr`.